### PR TITLE
v1.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         }
     ],
     "require": {
-        "php": "^8.2"
+        "php": "^8.2",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"

--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -24,10 +24,6 @@ This document describes the validation rules available in the `Azolee\Validator\
 - **Description**: Validates that the data is not null.
 - **Usage**: `not_null`
 
-### `not_equals_field`
-- **Description**: Validates that the data is not equal to the value of another field.
-- **Usage**: `not_equals_field:other_field`
-
 ### `email`
 - **Description**: Validates that the data is a valid email address.
 - **Usage**: `email`
@@ -92,4 +88,47 @@ This document describes the validation rules available in the `Azolee\Validator\
 - **Description**: Validates that the data is not empty.
 - **Usage**: `required`
 
-[<< Back to Readme](../Readme.md)
+### `alpha_dash`
+- **Description**: Validates that the data contains only alphabetic characters, numbers, dashes, and underscores.
+- **Usage**: `alpha_dash`
+
+### `after`
+- **Description**: Validates that the data is a date after a given date.
+- **Usage**: `after:date`
+
+### `before`
+- **Description**: Validates that the data is a date before a given date.
+- **Usage**: `before:date`
+
+### `active_url`
+- **Description**: Validates that the data is a valid URL and the domain has a DNS record.
+- **Usage**: `active_url`
+
+### `ascii`
+- **Description**: Validates that the data contains only ASCII characters.
+- **Usage**: `ascii`
+
+### `date_equals`
+- **Description**: Validates that the data is a date equal to a given date.
+- **Usage**: `date_equals:date`
+
+### `distinct`
+- **Description**: Validates that the field under validation does not have any duplicate values when validating arrays.
+- **Usage**: `distinct`
+- **Parameters**:
+    - `strict`: Use strict comparisons.
+    - `ignore_case`: Ignore capitalization differences.
+
+### Callable Rules
+
+Callable rules are custom validation rules defined as closures or callable functions. They should return a boolean value indicating whether the validation passed or failed.
+
+#### Example
+
+```php
+$validationRules = [
+    'field_name' => function ($data, $key, $dataToValidate) {
+        // Custom validation logic
+        return $data === 'expected_value';
+    },
+];

--- a/src/ValidationErrorManager.php
+++ b/src/ValidationErrorManager.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Azolee\Validator;
+
+use Azolee\Validator\Contracts\ValidationErrorBagInterface;
+
+class ValidationErrorManager
+{
+    protected ValidationResult $validationResult;
+
+    public function __construct(ValidationErrorBagInterface $validationErrorBag = null)
+    {
+        $this->validationResult = new ValidationResult($validationErrorBag ?? new ValidationErrorBag());
+    }
+
+    public function setFailed(string $rule, string $key, mixed $dataToValidate, ?string $message = null): void
+    {
+        $this->validationResult->setFailed($rule, $key, $dataToValidate, $message);
+    }
+
+    public function getValidationResult(): ValidationResult
+    {
+        return $this->validationResult;
+    }
+}

--- a/src/ValidationRuleEvaluator.php
+++ b/src/ValidationRuleEvaluator.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Azolee\Validator;
+
+use Azolee\Validator\Exceptions\InvalidValidationRule;
+use Azolee\Validator\Helpers\ArrayHelper;
+use Azolee\Validator\Helpers\ClassHelper;
+use InvalidArgumentException;
+use ReflectionException;
+
+class ValidationRuleEvaluator
+{
+    protected ValidationErrorManager $errorManager;
+
+    public function __construct(ValidationErrorManager $errorManager)
+    {
+        $this->errorManager = $errorManager;
+    }
+
+    /**
+     * @throws InvalidValidationRule
+     * @throws ReflectionException
+     */
+    public function evaluate(string|array|callable $rules, string $key, mixed $dataToValidate): void
+    {
+        if (!is_array($rules)) {
+            $rules = (is_string($rules) && str_contains($rules, '|')) ? explode('|', $rules) : [$rules];
+        }
+
+        foreach ($rules as $rule) {
+            if (ClassHelper::isCallable($rule)) {
+                if ($this->applyCallableRule($rule, $key, $dataToValidate) === false) {
+                    $this->errorManager->setFailed('custom_rule', $key, $dataToValidate);
+                    return;
+                }
+                continue;
+            }
+
+            if ($this->applyRule($rule, $key, $dataToValidate) === false) {
+                $this->errorManager->setFailed($rule, $key, $dataToValidate);
+                return;
+            }
+        }
+    }
+
+    /**
+     * @throws InvalidValidationRule
+     */
+    private function applyRule(string $rule, string $key, mixed $dataToValidate): bool
+    {
+        $validationRules = new ValidationRules();
+        $method = $rule;
+        $additionalAttribute = null;
+
+        if (str_contains($rule, ':')) {
+            [$method, $additionalAttribute] = explode(':', $rule, 2);
+        }
+
+        if (!method_exists($validationRules, $method)) {
+            throw new InvalidValidationRule("Validation method $method not implemented.");
+        }
+
+        $dataSet = ArrayHelper::parseNestedData($dataToValidate, $key);
+
+        foreach ($dataSet as $data) {
+            $result = $validationRules::$method($data['value'], $data['key'], $additionalAttribute, $dataToValidate);
+            if ($result === false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws InvalidValidationRule
+     * @throws ReflectionException
+     */
+    private function applyCallableRule(array|callable $rule, string $key, mixed $dataToValidate): bool
+    {
+        ClassHelper::validateCallable($rule, "Invalid closure passed for $key: should have 1-3 attributes: data, key and the dataArray.");
+
+        $data = $dataToValidate;
+        if ($key) {
+            $data = ArrayHelper::parseNestedData($dataToValidate, $key) ?? [];
+        }
+
+        $handleItem = function ($item) use ($rule, $key, $dataToValidate) {
+            if (array_key_exists('value', $item) === false || array_key_exists('key', $item) === false) {
+                throw new InvalidArgumentException("Invalid data structure for $key.");
+            }
+            $result = call_user_func($rule, ($item['value'] ?? null), ($item['key'] ?? $key), $dataToValidate);
+            if (gettype($result) !== 'boolean') {
+                throw new InvalidValidationRule("Validation rule for $key should return a boolean.");
+            }
+            return $result;
+        };
+
+        if (!array_is_list($data)) {
+            return $handleItem($data);
+        }
+
+        foreach ($data as $item) {
+            if ($handleItem($item) === false) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -266,4 +266,143 @@ class ValidationRules
     {
         return !empty($data);
     }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function contains(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        $values = explode(',', $value);
+        return in_array($data, $values);
+    }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function alpha_dash(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        return preg_match('/^[a-zA-Z0-9_-]+$/', $data) === 1;
+    }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function after(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        return strtotime($data) > strtotime($value);
+    }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function before(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        return strtotime($data) < strtotime($value);
+    }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function active_url(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        return filter_var($data, FILTER_VALIDATE_URL) !== false && checkdnsrr(parse_url($data, PHP_URL_HOST), 'A');
+    }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function ascii(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        return mb_check_encoding($data, 'ASCII');
+    }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function date_equals(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        return date('Y-m-d', strtotime($data)) === date('Y-m-d', strtotime($value));
+    }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function distinct(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        $strict = false;
+        $ignoreCase = false;
+
+        if ($value) {
+            $params = explode(',', $value);
+            $strict = in_array('strict', $params);
+            $ignoreCase = in_array('ignore_case', $params);
+        }
+
+        $keyParts = explode('.', $key);
+        $currentKey = array_pop($keyParts); // get the key to validate
+        array_pop($keyParts); // remove the * key
+
+        $values = ArrayHelper::parseNestedData($dataToValidate, implode('.', $keyParts));
+        $values = array_column(
+            (array_column($values, 'value')[0] ?? []),
+            $currentKey
+        );
+
+        if ($ignoreCase) {
+            $values = array_map('strtolower', $values);
+        }
+
+        return count($values) === count(array_unique($values, $strict ? SORT_STRING : SORT_REGULAR));
+    }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function date_format(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        $formats = explode(',', $value);
+        foreach ($formats as $format) {
+            $parsedDate = date_create_from_format($format, $data);
+            if ($parsedDate && $parsedDate->format($format) === $data) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -5,16 +5,13 @@ namespace Azolee\Validator;
 use Azolee\Validator\Contracts\ValidationErrorBagInterface;
 use Azolee\Validator\Exceptions\InvalidValidationRule;
 use Azolee\Validator\Exceptions\ValidationException;
-use Azolee\Validator\Helpers\ArrayHelper;
-use Azolee\Validator\Helpers\ClassHelper;
-use Exception;
-use InvalidArgumentException;
 use ReflectionException;
 
 class Validator
 {
     protected function __construct(
-        protected ValidationResult $lastValidationResult = new ValidationResult()
+        protected ValidationErrorManager $errorManager,
+        protected ValidationRuleEvaluator $ruleEvaluator
     ) {
     }
 
@@ -29,8 +26,9 @@ class Validator
         bool $silent = true,
         ValidationErrorBagInterface $validationErrorBag = null
     ): ValidationResult {
-        $validationResult = new ValidationResult($validationErrorBag ?? new ValidationErrorBag());
-        $validator = new self($validationResult);
+        $errorManager = new ValidationErrorManager($validationErrorBag);
+        $ruleEvaluator = new ValidationRuleEvaluator($errorManager);
+        $validator = new self($errorManager, $ruleEvaluator);
 
         try {
             foreach ($validationRules as $field => $rules) {
@@ -39,129 +37,28 @@ class Validator
                     if (!$silent) {
                         throw new InvalidValidationRule($message);
                     }
-                    $validator->lastValidationResult()->setFailed('invalid_rule', $field, $rules, $message);
+                    $validator->errorManager->setFailed('invalid_rule', $field, $rules, $message);
                     continue;
                 }
 
-                $validator->evaluate($rules, $field, $dataToValidate);
+                $validator->ruleEvaluator->evaluate($rules, $field, $dataToValidate);
 
-                if ($validator->failed() && !$silent) {
-                    throw new ValidationException($validator->lastValidationResult()->getErrorsForFailure());
+                if ($validator->errorManager->getValidationResult()->isFailed() && !$silent) {
+                    throw new ValidationException($validator->errorManager->getValidationResult()->getErrorsForFailure());
                 }
             }
-        } catch (Exception $e) {
+        } catch (InvalidValidationRule|ReflectionException|ValidationException $e) {
             if (!$silent) {
                 throw $e;
             }
-            $validator->lastValidationResult()->setFailed('', '', $dataToValidate, $e->getMessage());
+            $validator->errorManager->setFailed('', '', $dataToValidate, $e->getMessage());
         }
 
-        return $validator->lastValidationResult();
-    }
-
-    public function failed(): bool
-    {
-        return $this->lastValidationResult->isFailed();
-    }
-
-    public function lastValidationResult(): ValidationResult
-    {
-        return $this->lastValidationResult;
-    }
-
-    /**
-     * @throws InvalidValidationRule
-     * @throws ReflectionException
-     */
-    protected function evaluate(string|array|callable $rules, string $key, mixed $dataToValidate): void
-    {
-        if (!is_array($rules)) {
-            $rules = (is_string($rules) && str_contains($rules, '|')) ? explode('|', $rules) : [$rules];
-        }
-
-        foreach ($rules as $rule) {
-            if (ClassHelper::isCallable($rule)) {
-                if ($this->applyCallableRule($rule, $key, $dataToValidate) === false) {
-                    $this->lastValidationResult->setFailed('custom_rule', $key, $dataToValidate);
-                    return;
-                }
-                continue;
-            }
-
-            if ($this->applyRule($rule, $key, $dataToValidate) === false) {
-                $this->lastValidationResult->setFailed($rule, $key, $dataToValidate);
-                return;
-            }
-        }
+        return $validator->errorManager->getValidationResult();
     }
 
     protected function validateRuleTypes(mixed $rules): bool
     {
         return (is_string($rules) || is_callable($rules) || is_array($rules));
-    }
-
-    /**
-     * @throws InvalidValidationRule
-     */
-    private function applyRule(string $rule, string $key, mixed $dataToValidate): bool
-    {
-        $validationRules = new ValidationRules();
-        $method = $rule;
-        $additionalAttribute = null;
-
-        if (str_contains($rule, ':')) {
-            [$method, $additionalAttribute] = explode(':', $rule, 2);
-        }
-
-        if (!method_exists($validationRules, $method)) {
-            throw new InvalidValidationRule("Validaton method $method not implemented.");
-        }
-
-        $dataSet = ArrayHelper::parseNestedData($dataToValidate, $key);
-
-        foreach ($dataSet as $data) {
-            $result = $validationRules::$method($data['value'], $data['key'], $additionalAttribute, $dataToValidate);
-            if ($result === false) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     * @throws InvalidValidationRule
-     * @throws ReflectionException
-     */
-    private function applyCallableRule(array|callable $rule, string $key, mixed $dataToValidate): bool
-    {
-        ClassHelper::validateCallable($rule, "Invalid closure passed for $key: should have 1-3 attributes: data, key and the dataArray.");
-
-        $data = $dataToValidate;
-        if ($key) {
-            $data = ArrayHelper::parseNestedData($dataToValidate, $key) ?? [];
-        }
-
-        $handleItem = function ($item) use ($rule, $key, $dataToValidate) {
-            if (array_key_exists('value', $item) === false || array_key_exists('key', $item) === false) {
-                throw new InvalidArgumentException("Invalid data structure for $key.");
-            }
-            $result = call_user_func($rule, ($item['value'] ?? null), ($item['key'] ?? $key), $dataToValidate);
-            if (gettype($result) !== 'boolean') {
-                throw new InvalidValidationRule("Validation rule for $key should return a boolean.");
-            }
-            return $result;
-        };
-
-        if (!array_is_list($data)) {
-            return $handleItem($data);
-        }
-
-        foreach ($data as $item) {
-            if ($handleItem($item) === false) {
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -576,6 +576,171 @@ class ValidatorTest extends TestCase
         $this->assertTrue($result->isFailed());
     }
 
+    public function testAlphaDash()
+    {
+        $validationRules = [
+            'username' => 'alpha_dash',
+        ];
+        $dataToValidate = [
+            'username' => 'john_doe-123',
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+
+        $dataToValidate['username'] = 'john@doe';
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+    }
+
+    public function testAfter()
+    {
+        $validationRules = [
+            'start_date' => 'after:2023-01-01',
+        ];
+        $dataToValidate = [
+            'start_date' => '2023-01-02',
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+
+        $dataToValidate['start_date'] = '2022-12-31';
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+    }
+
+    public function testBefore()
+    {
+        $validationRules = [
+            'end_date' => 'before:2023-01-01',
+        ];
+        $dataToValidate = [
+            'end_date' => '2022-12-31',
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+
+        $dataToValidate['end_date'] = '2023-01-02';
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+    }
+
+    public function testActiveUrl()
+    {
+        $validationRules = [
+            'website' => 'active_url',
+        ];
+        $dataToValidate = [
+            'website' => 'https://www.google.com',
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+
+        $dataToValidate['website'] = 'https://invalid-url.com';
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+    }
+
+    public function testAscii()
+    {
+        $validationRules = [
+            'text' => 'ascii',
+        ];
+        $dataToValidate = [
+            'text' => 'Hello World!',
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+
+        $dataToValidate['text'] = 'こんにちは世界';
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+    }
+
+    public function testDateEquals()
+    {
+        $validationRules = [
+            'event_date' => 'date_equals:2023-01-01',
+        ];
+        $dataToValidate = [
+            'event_date' => '2023-01-01',
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+
+        $dataToValidate['event_date'] = '2023-01-02';
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+    }
+
+    public function testDistinct()
+    {
+        $validationRules = [
+            'items.*.id' => 'distinct',
+        ];
+        $dataToValidate = [
+            'items' => [
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+            ],
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+
+        $dataToValidate['items'][2]['id'] = 2;
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+    }
+
+    public function testDistinctStrict()
+    {
+        $validationRules = [
+            'items.*.id' => 'distinct:strict',
+        ];
+        $dataToValidate = [
+            'items' => [
+                ['id' => 1],
+                ['id' => '1'],
+                ['id' => 2],
+            ],
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+
+        $dataToValidate['items'][1]['id'] = 3;
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+    }
+
+    public function testDistinctIgnoreCase()
+    {
+        $validationRules = [
+            'items.*.name' => 'distinct:ignore_case',
+        ];
+        $dataToValidate = [
+            'items' => [
+                ['name' => 'Item1'],
+                ['name' => 'item1'],
+                ['name' => 'Item2'],
+            ],
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+
+        $dataToValidate['items'][1]['name'] = 'Item3';
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+    }
+
     public function testMakeWithClassMethodRule()
     {
         $validationRules = [


### PR DESCRIPTION
This pull request introduces several significant changes to the validation system, including new validation rules, refactoring of the validation architecture, and updates to the documentation and tests.

### New Validation Rules:
* Added new validation rules such as `alpha_dash`, `after`, `before`, `active_url`, `ascii`, `date_equals`, `distinct`, and `date_format` in `ValidationRules.php`.

### Refactoring and Code Improvements:
* Introduced `ValidationErrorManager` and `ValidationRuleEvaluator` classes to handle validation errors and rule evaluation, respectively. This refactoring simplifies the `Validator` class and separates concerns. [[1]](diffhunk://#diff-f95afb9d9198c019cb5f8d5ab309a6e71b6a43ffbeddd7e48e8fd03d6901d74bR1-R25) [[2]](diffhunk://#diff-55bee6e6e237886724f80693c971f1d32265f86c157c020d51d48887e5ddce82R1-R110) [[3]](diffhunk://#diff-9dad0f0dabc730596b3399e6fe25aed903dba8bc7836fe778fce387cf9f3e111L8-R14)
* Updated `Validator.php` to use the new `ValidationErrorManager` and `ValidationRuleEvaluator` classes, removing redundant methods and improving error handling. [[1]](diffhunk://#diff-9dad0f0dabc730596b3399e6fe25aed903dba8bc7836fe778fce387cf9f3e111L32-R31) [[2]](diffhunk://#diff-9dad0f0dabc730596b3399e6fe25aed903dba8bc7836fe778fce387cf9f3e111L42-L166)

### Documentation Updates:
* Updated `docs/Rules.md` to include descriptions and usage examples for the new validation rules, and removed the outdated `not_equals_field` rule. [[1]](diffhunk://#diff-d631fe82f8335589a701a32360cf291e6c3de7e2e48764273a337e41195271bcL27-L30) [[2]](diffhunk://#diff-d631fe82f8335589a701a32360cf291e6c3de7e2e48764273a337e41195271bcL95-R134)

### Dependency Updates:
* Modified `composer.json` to require the `ext-mbstring` extension.

### Testing Enhancements:
* Added new test cases in `ValidatorTest.php` to cover the newly introduced validation rules, ensuring their correctness and reliability.