### PR TITLE
Make sure ValidationResult will return distinct errors

### DIFF
--- a/src/ValidationResult.php
+++ b/src/ValidationResult.php
@@ -74,12 +74,20 @@ class ValidationResult
      */
     public function getErrorsForFailure(): string
     {
+        return join(", ", $this->getErrorsForFields());
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrorsForFields(): array
+    {
         $errors = [];
 
         foreach ($this->failedRules as $failedRule) {
-            $errors[] = $failedRule['message'] ?? $this->validationError->getErrorFor($failedRule['rule'], $failedRule['key']);
+            $errors[$failedRule['key']] = $failedRule['message'] ?? $this->validationError->getErrorFor($failedRule['rule'], $failedRule['key']);
         }
 
-        return join(", ", $errors);
+        return $errors;
     }
 }


### PR DESCRIPTION
This pull request makes changes to the `src/ValidationResult.php` file to improve error handling and reporting. The most significant change is the addition of a new method to retrieve errors for fields as an array, which is then used to format the error messages into a string.

Changes to error handling and reporting:

* Added `public function getErrorsForFields(): array` method to return an array of errors for each field.
* Modified `public function getErrorsForFailure(): string` method to use `getErrorsForFields()` for formatting error messages.