### PR TITLE
Add UUID validation rule

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -156,6 +156,11 @@ This document describes the validation rules available in the `Azolee\Validator\
 - **Parameters**:
   - `charset`: The character set to validate against (e.g., UTF-8, ISO-8859-1).
 
+### `uuid`
+- **Description**: Validates that the data is a valid UUID.
+- **Usage**: `uuid`
+- **Parameters**: None
+
 ### Callable Rules
 
 Callable rules are custom validation rules defined as closures or callable functions. They should return a boolean value indicating whether the validation passed or failed.

--- a/docs/SimpleExamples.md
+++ b/docs/SimpleExamples.md
@@ -22,6 +22,8 @@
 20. [Base64 Image](#example-base64-image)
 21. [Present](#example-present)
 22. [Different](#example-different)
+23. [Charset](#example-charset)
+23. [UUID](#example-uuid)
 
 
 
@@ -883,7 +885,37 @@ $dataToValidate = [
 ];
 
 $result = Validator::make($validationRules, $dataToValidate);
+if ($result->isFailed()) {
+    echo "Validation failed";
+} else {
+    echo "Validation successful!";
+}
 ```
+
 If the string is not valid in the specified charset, the validation will fail.
+
+
+### Example: `UUID`
+
+The `UUID` rule validates that the data is a valid UUID.
+
+**Usage:**
+
+```php
+$validationRules = [
+    'uuid' => 'uuid',
+];
+$dataToValidate = [
+    'uuid' => '123e4567-e89b-12d3-a456-426614174000',
+];
+
+$result = Validator::make($validationRules, $dataToValidate);
+if ($result->isFailed()) {
+    echo "Validation failed";
+} else {
+    echo "Validation successful!";
+}
+```
+
 
 [<< Back to Readme](../Readme.md)

--- a/src/ValidationErrorBag.php
+++ b/src/ValidationErrorBag.php
@@ -44,6 +44,7 @@ class ValidationErrorBag implements ValidationErrorBagInterface
         'base64_image' => 'The :attribute must be a valid base64 encoded image.',
         'present' => 'The :attribute field must be present.',
         'charset' => 'The :attribute is not valid :value charset.',
+        'uuid' => 'The :attribute is not a valid UUID.',
     ];
 
     /**

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -521,4 +521,16 @@ class ValidationRules
 
         return mb_check_encoding($data, $value);
     }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function uuid(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        return preg_match('/^\{?[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\}?$/', $data) === 1;
+    }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1135,4 +1135,22 @@ class ValidatorTest extends TestCase
         $result = Validator::make($validationRules, $dataToValidate);
         $this->assertTrue($result->isFailed());
     }
+
+    public function testValidatorWithUuidRule()
+    {
+        $validationRules = [
+            'uuid-field' => 'uuid',
+        ];
+        $dataToValidate = [
+            'uuid-field' => '123e4567-e89b-12d3-a456-426614174000',
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+
+        $dataToValidate['uuid-field'] = 'invalid-uuid';
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+        $this->assertEquals('The uuid-field is not a valid UUID.', $result->getFailedRules()[0]['message']);
+    }
 }


### PR DESCRIPTION
This pull request introduces a new validation rule for UUIDs in the `Azolee\Validator` library. The changes include updates to the documentation, the addition of the validation rule itself, and new tests to ensure the rule works correctly.

### Documentation Updates:
* [`docs/Rules.md`](diffhunk://#diff-d631fe82f8335589a701a32360cf291e6c3de7e2e48764273a337e41195271bcR159-R163): Added a new section for the `uuid` rule, including its description, usage, and parameters.
* [`docs/SimpleExamples.md`](diffhunk://#diff-6b909db0f6696098ff022ecc91b64a06491351c8ae4c9a5a8d30a9bb65dc6ba4R25-R26): Updated the table of contents to include the `charset` and `UUID` examples, and added an example usage of the `UUID` rule. [[1]](diffhunk://#diff-6b909db0f6696098ff022ecc91b64a06491351c8ae4c9a5a8d30a9bb65dc6ba4R25-R26) [[2]](diffhunk://#diff-6b909db0f6696098ff022ecc91b64a06491351c8ae4c9a5a8d30a9bb65dc6ba4R888-R920)

### Codebase Updates:
* [`src/ValidationRules.php`](diffhunk://#diff-5426aa857e20a3fe214156ea81bdf6e235d3b1a7fd6d900b5464197ada40ff89R524-R535): Added the `uuid` validation rule, which uses a regular expression to check if the data is a valid UUID.
* [`src/ValidationErrorBag.php`](diffhunk://#diff-71928e9b9fd22f2c56a0da2e391aff7ab242a6604dfa6bc2a5fbdd557e3db27dR47): Added a new error message for the `uuid` validation rule.

### Tests:
* [`tests/ValidatorTest.php`](diffhunk://#diff-4c4ee9a70c948a730af8666ce53bb435817847be9ab1f4cf7dadfb15e82aed62R1138-R1155): Added a new test case `testValidatorWithUuidRule` to verify the functionality of the `uuid` validation rule.