### PR TITLE
Create the slug and the IBAN validation rules

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -159,7 +159,15 @@ This document describes the validation rules available in the `Azolee\Validator\
 ### `uuid`
 - **Description**: Validates that the data is a valid UUID.
 - **Usage**: `uuid`
-- **Parameters**: None
+
+### `slug`
+- **Description**: Validates that the data is a valid slug (lowercase letters, numbers, and hyphens).
+- **Usage**: `slug`
+
+### `iban`
+- **Description**: Validates that the data is a valid IBAN.
+- **Usage**: `iban`
+
 
 ### Callable Rules
 
@@ -174,3 +182,4 @@ $validationRules = [
         return $data === 'expected_value';
     },
 ];
+```

--- a/docs/SimpleExamples.md
+++ b/docs/SimpleExamples.md
@@ -23,7 +23,9 @@
 21. [Present](#example-present)
 22. [Different](#example-different)
 23. [Charset](#example-charset)
-23. [UUID](#example-uuid)
+24. [UUID](#example-uuid)
+25. [Slug](#example-slug)
+26. [IBAN](#example-iban)
 
 
 
@@ -917,5 +919,62 @@ if ($result->isFailed()) {
 }
 ```
 
+### Example: `Slug`
+
+This code validates that the `slug` field contains a valid slug (lowercase letters, numbers, and hyphens). It first checks a valid slug (`valid-slug-123`) and then an invalid one (`Invalid Slug!`).
+
+```php
+$validationRules = [
+    'slug' => 'slug',
+];
+$dataToValidate = [
+    'slug' => 'valid-slug-123',
+];
+
+$result = Validator::make($validationRules, $dataToValidate);
+if ($result->isFailed()) {
+    echo "Validation failed";
+} else {
+    echo "Validation successful!";
+}
+
+$dataToValidate['slug'] = 'Invalid Slug!';
+$result = Validator::make($validationRules, $dataToValidate);
+if ($result->isFailed()) {
+    echo "Validation failed";
+} else {
+    echo "Validation successful!";
+}
+```
+
+### Example: `IBAN`
+
+This code validates that the `iban` field contains a valid IBAN. It first checks a valid IBAN (`GB82WEST12345698765432`) and then an invalid one (`invalid-iban`).
+
+```php
+$validationRules = [
+    'iban' => 'iban',
+];
+$dataToValidate = [
+    'iban' => 'GB82WEST12345698765432',
+];
+
+$result = Validator::make($validationRules, $dataToValidate);
+if ($result->isFailed()) {
+    echo "Validation failed";
+} else {
+    echo "Validation successful!";
+}
+
+$dataToValidate['iban'] = 'invalid-iban';
+$result = Validator::make($validationRules, $dataToValidate);
+if ($result->isFailed()) {
+    echo "Validation failed";
+} else {
+    echo "Validation successful!";
+}
+```
+
+[^ Back to top](#table-of-contents)
 
 [<< Back to Readme](../Readme.md)

--- a/src/ValidationErrorBag.php
+++ b/src/ValidationErrorBag.php
@@ -45,6 +45,8 @@ class ValidationErrorBag implements ValidationErrorBagInterface
         'present' => 'The :attribute field must be present.',
         'charset' => 'The :attribute is not valid :value charset.',
         'uuid' => 'The :attribute is not a valid UUID.',
+        'slug' => 'The :attribute is not a valid slug.',
+        'iban' => 'The :attribute is not a valid IBAN.',
     ];
 
     /**

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -533,4 +533,58 @@ class ValidationRules
     {
         return preg_match('/^\{?[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\}?$/', $data) === 1;
     }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function slug(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        return preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $data) === 1;
+    }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function iban(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        $iban = strtolower(str_replace(' ', '', $data));
+        $countries = [
+            'al' => 28, 'ad' => 24, 'at' => 20, 'az' => 28, 'bh' => 22, 'be' => 16, 'ba' => 20, 'br' => 29,
+            'bg' => 22, 'cr' => 21, 'hr' => 21, 'cy' => 28, 'cz' => 24, 'dk' => 18, 'do' => 28, 'ee' => 20,
+            'fo' => 18, 'fi' => 18, 'fr' => 27, 'ge' => 22, 'de' => 22, 'gi' => 23, 'gr' => 27, 'gl' => 18,
+            'gt' => 28, 'hu' => 28, 'is' => 26, 'ie' => 22, 'il' => 23, 'it' => 27, 'jo' => 30, 'kz' => 20,
+            'kw' => 30, 'lv' => 21, 'lb' => 28, 'li' => 21, 'lt' => 20, 'lu' => 20, 'mk' => 19, 'mt' => 31,
+            'mr' => 27, 'mu' => 30, 'mc' => 27, 'md' => 24, 'me' => 22, 'nl' => 18, 'no' => 15, 'pk' => 24,
+            'ps' => 29, 'pl' => 28, 'pt' => 25, 'qa' => 29, 'ro' => 24, 'sm' => 27, 'sa' => 24, 'rs' => 22,
+            'sk' => 24, 'si' => 19, 'es' => 24, 'se' => 24, 'ch' => 21, 'tn' => 24, 'tr' => 26, 'ae' => 23,
+            'gb' => 22, 'vg' => 24
+        ];
+
+        $countryCode = substr($iban, 0, 2);
+        if (!isset($countries[$countryCode]) || strlen($iban) != $countries[$countryCode]) {
+            return false;
+        }
+
+        $iban = substr($iban, 4) . substr($iban, 0, 4);
+        $iban = str_replace(
+            range('a', 'z'),
+            range(10, 35),
+            $iban
+        );
+
+        $checksum = intval(substr($iban, 0, 1));
+        for ($i = 1; $i < strlen($iban); $i++) {
+            $checksum = ($checksum * 10 + intval(substr($iban, $i, 1))) % 97;
+        }
+
+        return $checksum == 1;
+    }
 }

--- a/tests/ValidatorTest1.php
+++ b/tests/ValidatorTest1.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests;
+
+use Azolee\Validator\Exceptions\InvalidValidationRule;
+use Azolee\Validator\Exceptions\ValidationException;
+use Azolee\Validator\Validator;
+use PHPUnit\Framework\TestCase;
+use Tests\Helpers\CustomRules;
+
+class ValidatorTest1 extends TestCase
+{
+    public function testValidatorWithSlugRule()
+    {
+        $validationRules = [
+            'slug-field' => 'slug',
+        ];
+        $dataToValidate = [
+            'slug-field' => 'valid-slug-123',
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+
+        $dataToValidate['slug-field'] = 'Invalid Slug!';
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+        $this->assertEquals('The slug-field is not a valid slug.', $result->getFailedRules()[0]['message']);
+    }
+
+    public function testValidatorWithIbanRule()
+    {
+        $validationRules = [
+            'iban-no' => 'iban',
+        ];
+        $dataToValidate = [
+            'iban-no' => 'GB82WEST12345698765432',
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+
+        $dataToValidate['iban-no'] = 'invalid-iban';
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+        $this->assertEquals('The iban-no is not a valid IBAN.', $result->getFailedRules()[0]['message']);
+    }
+}


### PR DESCRIPTION
This pull request introduces new validation rules for `slug` and `iban` in the `Azolee\Validator` package. It includes updates to the documentation, the validation rules implementation, and the test cases.

### New Validation Rules:

* Added `slug` validation rule to ensure data contains only lowercase letters, numbers, and hyphens. (`docs/Rules.md`, `src/ValidationRules.php`, `src/ValidationErrorBag.php`, `tests/ValidatorTest1.php`) [[1]](diffhunk://#diff-d631fe82f8335589a701a32360cf291e6c3de7e2e48764273a337e41195271bcL162-R170) [[2]](diffhunk://#diff-5426aa857e20a3fe214156ea81bdf6e235d3b1a7fd6d900b5464197ada40ff89R536-R589) [[3]](diffhunk://#diff-71928e9b9fd22f2c56a0da2e391aff7ab242a6604dfa6bc2a5fbdd557e3db27dR48-R49) [[4]](diffhunk://#diff-d9da6cab1054c2e5db9708d0ed75dc8675fb0724deb0964c9bb548d26f469f37R1-R48)
* Added `iban` validation rule to ensure data is a valid International Bank Account Number (IBAN). (`docs/Rules.md`, `src/ValidationRules.php`, `src/ValidationErrorBag.php`, `tests/ValidatorTest1.php`) [[1]](diffhunk://#diff-d631fe82f8335589a701a32360cf291e6c3de7e2e48764273a337e41195271bcL162-R170) [[2]](diffhunk://#diff-5426aa857e20a3fe214156ea81bdf6e235d3b1a7fd6d900b5464197ada40ff89R536-R589) [[3]](diffhunk://#diff-71928e9b9fd22f2c56a0da2e391aff7ab242a6604dfa6bc2a5fbdd557e3db27dR48-R49) [[4]](diffhunk://#diff-d9da6cab1054c2e5db9708d0ed75dc8675fb0724deb0964c9bb548d26f469f37R1-R48)

### Documentation Updates:

* Updated `docs/Rules.md` to include descriptions and usage for `slug` and `iban` validation rules.
* Added examples for `slug` and `iban` validation in `docs/SimpleExamples.md`. [[1]](diffhunk://#diff-6b909db0f6696098ff022ecc91b64a06491351c8ae4c9a5a8d30a9bb65dc6ba4L26-R28) [[2]](diffhunk://#diff-6b909db0f6696098ff022ecc91b64a06491351c8ae4c9a5a8d30a9bb65dc6ba4R922-R978)

### Test Cases:

* Added test cases for `slug` and `iban` validation rules in `tests/ValidatorTest1.php`.