### PR TITLE
[new rule] Create the hex_color validation rule

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -168,12 +168,15 @@ This document describes the validation rules available in the `Azolee\Validator\
 - **Description**: Validates that the data is a valid IBAN.
 - **Usage**: `iban`
 
+### `hex_color`
+- **Description**: Validates that the data is a valid hex color code.
+- **Usage**: `hex_color`
 
-### Callable Rules
+## Callable Rules
 
 Callable rules are custom validation rules defined as closures or callable functions. They should return a boolean value indicating whether the validation passed or failed.
 
-#### Example
+### Example
 
 ```php
 $validationRules = [

--- a/docs/SimpleExamples.md
+++ b/docs/SimpleExamples.md
@@ -26,6 +26,7 @@
 24. [UUID](#example-uuid)
 25. [Slug](#example-slug)
 26. [IBAN](#example-iban)
+27. [Hex Color](#example-hex-color)
 
 
 
@@ -967,6 +968,34 @@ if ($result->isFailed()) {
 }
 
 $dataToValidate['iban'] = 'invalid-iban';
+$result = Validator::make($validationRules, $dataToValidate);
+if ($result->isFailed()) {
+    echo "Validation failed";
+} else {
+    echo "Validation successful!";
+}
+```
+
+### Example: `Hex Color`
+
+This code validates that the `color` field contains a valid hex color code. It first checks a valid hex color (`#aabbcc`) and then an invalid one (`invalid-color`).
+
+```php
+$validationRules = [
+    'color' => 'hex_color',
+];
+$dataToValidate = [
+    'color' => '#aabbcc',
+];
+
+$result = Validator::make($validationRules, $dataToValidate);
+if ($result->isFailed()) {
+    echo "Validation failed";
+} else {
+    echo "Validation successful!";
+}
+
+$dataToValidate['color'] = 'invalid-color';
 $result = Validator::make($validationRules, $dataToValidate);
 if ($result->isFailed()) {
     echo "Validation failed";

--- a/src/ValidationErrorBag.php
+++ b/src/ValidationErrorBag.php
@@ -47,6 +47,7 @@ class ValidationErrorBag implements ValidationErrorBagInterface
         'uuid' => 'The :attribute is not a valid UUID.',
         'slug' => 'The :attribute is not a valid slug.',
         'iban' => 'The :attribute is not a valid IBAN.',
+        'hex_color' => 'The :attribute is not a valid hex color.',
     ];
 
     /**

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -587,4 +587,16 @@ class ValidationRules
 
         return $checksum == 1;
     }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function hex_color(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        return preg_match('/^#?([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/', $data) === 1;
+    }
 }

--- a/tests/ValidatorTest1.php
+++ b/tests/ValidatorTest1.php
@@ -45,4 +45,22 @@ class ValidatorTest1 extends TestCase
         $this->assertTrue($result->isFailed());
         $this->assertEquals('The iban-no is not a valid IBAN.', $result->getFailedRules()[0]['message']);
     }
+
+    public function testValidatorWithHexColorRule()
+    {
+        $validationRules = [
+            'color' => 'hex_color',
+        ];
+        $dataToValidate = [
+            'color' => '#aabbcc',
+        ];
+
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertFalse($result->isFailed());
+
+        $dataToValidate['color'] = 'invalid-color';
+        $result = Validator::make($validationRules, $dataToValidate);
+        $this->assertTrue($result->isFailed());
+        $this->assertEquals('The color is not a valid hex color.', $result->getFailedRules()[0]['message']);
+    }
 }


### PR DESCRIPTION
This pull request introduces a new validation rule for hex color codes to the `Azolee\Validator` library. The changes include updates to the documentation, the addition of the validation rule, and corresponding test cases.

### New Validation Rule for Hex Color Codes:

* **Documentation Updates:**
  * Added `hex_color` validation rule description and usage in `docs/Rules.md`.
  * Included an example of using the `hex_color` validation rule in `docs/SimpleExamples.md`.
  * Updated the table of contents in `docs/SimpleExamples.md` to include the hex color example.

* **Codebase Updates:**
  * Added the `hex_color` validation rule to the `ValidationErrorBag` class in `src/ValidationErrorBag.php`.
  * Implemented the `hex_color` validation rule in the `ValidationRules` class in `src/ValidationRules.php`.

* **Testing:**
  * Added test cases for the `hex_color` validation rule in `tests/ValidatorTest1.php`.