### PR TITLE
Add timezone validation rule

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -172,6 +172,10 @@ This document describes the validation rules available in the `Azolee\Validator\
 - **Description**: Validates that the data is a valid hex color code.
 - **Usage**: `hex_color`
 
+### `timezone`
+- **Description**: Validates that the data is a valid timezone identifier.
+- **Usage**: `timezone`
+
 ## Callable Rules
 
 Callable rules are custom validation rules defined as closures or callable functions. They should return a boolean value indicating whether the validation passed or failed.

--- a/docs/SimpleExamples.md
+++ b/docs/SimpleExamples.md
@@ -1004,6 +1004,28 @@ if ($result->isFailed()) {
 }
 ```
 
+### Example: `Timezone Validation`
+
+This code validates that the `user_timezone` field contains a valid timezone representation.
+
+```php
+
+$data = [
+    'user_timezone' => 'America/New_York',
+];
+
+$rules = [
+    'user_timezone' => 'timezone',
+];
+
+$validator = Validator::make($rules, $data);
+
+if ($validator->fails()) {
+    echo "Validation failed.";
+} else {
+    echo "Validation passed.";
+}
+
 [^ Back to top](#table-of-contents)
 
 [<< Back to Readme](../Readme.md)

--- a/src/ValidationErrorBag.php
+++ b/src/ValidationErrorBag.php
@@ -48,6 +48,7 @@ class ValidationErrorBag implements ValidationErrorBagInterface
         'slug' => 'The :attribute is not a valid slug.',
         'iban' => 'The :attribute is not a valid IBAN.',
         'hex_color' => 'The :attribute is not a valid hex color.',
+        'timezone' => 'The :attribute is not a valid timezone.',
     ];
 
     /**

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -599,4 +599,16 @@ class ValidationRules
     {
         return preg_match('/^#?([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/', $data) === 1;
     }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function timezone(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        return in_array($data, timezone_identifiers_list(), true);
+    }
 }

--- a/tests/ValidatorTest1.php
+++ b/tests/ValidatorTest1.php
@@ -63,4 +63,27 @@ class ValidatorTest1 extends TestCase
         $this->assertTrue($result->isFailed());
         $this->assertEquals('The color is not a valid hex color.', $result->getFailedRules()[0]['message']);
     }
+
+    public function testTimezoneValidation()
+    {
+        $data = [
+            'user_timezone' => 'America/New_York',
+        ];
+
+        $rules = [
+            'user_timezone' => 'timezone',
+        ];
+
+        $result = Validator::make($rules, $data);
+
+        $this->assertFalse($result->isFailed());
+
+        $data = [
+            'user_timezone' => 'Invalid/Timezone',
+        ];
+
+        $result = Validator::make($rules, $data);
+
+        $this->assertTrue($result->isFailed());
+    }
 }


### PR DESCRIPTION
This pull request introduces a new validation rule for timezones and updates the documentation, validation error messages, and tests accordingly. The most important changes include the addition of the `timezone` validation rule, updates to the documentation to include examples of the new rule, and the inclusion of new test cases to ensure the rule works correctly.

### New Validation Rule for Timezones:

* [`src/ValidationRules.php`](diffhunk://#diff-5426aa857e20a3fe214156ea81bdf6e235d3b1a7fd6d900b5464197ada40ff89R602-R613): Added a new `timezone` validation rule to check if the data is a valid timezone identifier.

### Documentation Updates:

* [`docs/Rules.md`](diffhunk://#diff-d631fe82f8335589a701a32360cf291e6c3de7e2e48764273a337e41195271bcR175-R178): Added a description and usage example for the new `timezone` validation rule.
* [`docs/SimpleExamples.md`](diffhunk://#diff-6b909db0f6696098ff022ecc91b64a06491351c8ae4c9a5a8d30a9bb65dc6ba4R1007-R1028): Added an example demonstrating how to use the `timezone` validation rule.

### Validation Error Messages:

* [`src/ValidationErrorBag.php`](diffhunk://#diff-71928e9b9fd22f2c56a0da2e391aff7ab242a6604dfa6bc2a5fbdd557e3db27dR51): Updated the validation error messages to include a message for the `timezone` rule.

### Test Cases:

* [`tests/ValidatorTest1.php`](diffhunk://#diff-d9da6cab1054c2e5db9708d0ed75dc8675fb0724deb0964c9bb548d26f469f37R66-R88): Added new test cases to verify the functionality of the `timezone` validation rule.