### PR TITLE
Add `min_words` and `max_words` rules

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -176,6 +176,18 @@ This document describes the validation rules available in the `Azolee\Validator\
 - **Description**: Validates that the data is a valid timezone identifier.
 - **Usage**: `timezone`
 
+### `min_words`
+- **Description**: Validates that the given string contains at least a specified number of words.
+- **Usage**: `min_words:3`
+- **Parameters**:
+  - `value` (int): The minimum number of words required.
+  
+### `max_words`
+- **Description**: Validates that the given string contains no more than a specified number of words.
+- **Usage**: `max_words:5`
+- **Parameters**:
+  - `value` (int): The maximum number of words allowed.
+
 ## Callable Rules
 
 Callable rules are custom validation rules defined as closures or callable functions. They should return a boolean value indicating whether the validation passed or failed.

--- a/docs/SimpleExamples.md
+++ b/docs/SimpleExamples.md
@@ -1025,6 +1025,39 @@ if ($validator->fails()) {
 } else {
     echo "Validation passed.";
 }
+```
+
+### Example: `Min Words`
+
+This code validates that the given string contains at least a specified number of words.
+
+```php
+$rules = ['description' => 'min_words:3'];
+$data = ['description' => 'This is a test'];
+$result = Validator::make($rules, $data);
+
+if ($validator->fails()) {
+    echo "Validation failed.";
+} else {
+    echo "Validation passed.";
+}
+```
+
+### Example: `Max Words`
+
+This code validates that the given string contains at most a specified number of words.
+
+```php
+$rules = ['description' => 'max_words:5'];
+$data = ['description' => 'This is a simple test'];
+$result = Validator::make($rules, $data);
+
+if ($validator->fails()) {
+    echo "Validation failed.";
+} else {
+    echo "Validation passed.";
+}
+```
 
 [^ Back to top](#table-of-contents)
 

--- a/src/ValidationErrorBag.php
+++ b/src/ValidationErrorBag.php
@@ -49,6 +49,8 @@ class ValidationErrorBag implements ValidationErrorBagInterface
         'iban' => 'The :attribute is not a valid IBAN.',
         'hex_color' => 'The :attribute is not a valid hex color.',
         'timezone' => 'The :attribute is not a valid timezone.',
+        'min_words' => 'The :attribute must be at least :value words long.',
+        'max_words' => 'The :attribute must be at most :value words long.',
     ];
 
     /**

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -611,4 +611,30 @@ class ValidationRules
     {
         return in_array($data, timezone_identifiers_list(), true);
     }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function min_words(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        $wordCount = str_word_count($data);
+        return $wordCount >= $value;
+    }
+
+    /**
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function max_words(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        $wordCount = str_word_count($data);
+        return $wordCount <= $value;
+    }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -695,7 +695,7 @@ class ValidatorTest extends TestCase
         $result = Validator::make($validationRules, $dataToValidate);
         $this->assertFalse($result->isFailed());
 
-        $dataToValidate['website'] = 'https://invalid-url.com';
+        $dataToValidate['website'] = 'https://khgvncabcasbqiuw.com';
         $result = Validator::make($validationRules, $dataToValidate);
         $this->assertTrue($result->isFailed());
     }

--- a/tests/ValidatorTest1.php
+++ b/tests/ValidatorTest1.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Azolee\Validator\Exceptions\InvalidValidationRule;
 use Azolee\Validator\Exceptions\ValidationException;
+use Azolee\Validator\ValidationRules;
 use Azolee\Validator\Validator;
 use PHPUnit\Framework\TestCase;
 use Tests\Helpers\CustomRules;
@@ -84,6 +85,47 @@ class ValidatorTest1 extends TestCase
 
         $result = Validator::make($rules, $data);
 
+        $this->assertTrue($result->isFailed());
+    }
+    public function testMinWords()
+    {
+        $data = [
+            'description' => 'This is a test',
+        ];
+
+        $rules = [
+            'description' => 'min_words:3',
+        ];
+
+        $result = Validator::make($rules, $data);
+        $this->assertFalse($result->isFailed());
+
+        $data = [
+            'description' => 'Test',
+        ];
+
+        $result = Validator::make($rules, $data);
+        $this->assertTrue($result->isFailed());
+    }
+
+    public function testMaxWords()
+    {
+        $data = [
+            'description' => 'This is a simple test',
+        ];
+
+        $rules = [
+            'description' => 'max_words:5',
+        ];
+
+        $result = Validator::make($rules, $data);
+        $this->assertFalse($result->isFailed());
+
+        $data = [
+            'description' => 'This is a very simple test with too many words',
+        ];
+
+        $result = Validator::make($rules, $data);
         $this->assertTrue($result->isFailed());
     }
 }


### PR DESCRIPTION
This pull request introduces new validation rules for word count, updates the documentation to reflect these changes, and adds corresponding test cases. The most important changes include the addition of `min_words` and `max_words` validation rules, updates to the validation error messages, and new examples in the documentation.

### New Validation Rules:
* Added `min_words` validation rule to ensure a string contains at least a specified number of words. (`src/ValidationRules.php`)
* Added `max_words` validation rule to ensure a string contains no more than a specified number of words. (`src/ValidationRules.php`)

### Documentation Updates:
* Updated `docs/Rules.md` to include descriptions and usage examples for `min_words` and `max_words` validation rules.
* Added examples in `docs/SimpleExamples.md` to demonstrate the usage of `min_words` and `max_words` validation rules.

### Validation Error Messages:
* Updated `src/ValidationErrorBag.php` to include error messages for `min_words` and `max_words` validation rules.

### Test Cases:
* Added test cases for `min_words` and `max_words` validation rules in `tests/ValidatorTest1.php`.
* Minor update in `tests/ValidatorTest.php` for URL validation test data.
* Included `ValidationRules` in `tests/ValidatorTest1.php`.