### PR TITLE
Add Bail rule and create CustomRule interface

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -188,6 +188,11 @@ This document describes the validation rules available in the `Azolee\Validator\
 - **Parameters**:
   - `value` (int): The maximum number of words allowed.
 
+### `bail`
+- **Description**: Stops further validation for a field as soon as one rule fails.
+- **Usage**: `bail`
+
+
 ## Callable Rules
 
 Callable rules are custom validation rules defined as closures or callable functions. They should return a boolean value indicating whether the validation passed or failed.

--- a/docs/SimpleExamples.md
+++ b/docs/SimpleExamples.md
@@ -1059,6 +1059,38 @@ if ($validator->fails()) {
 }
 ```
 
+### Example: `Bail`
+
+This code demonstrates the `bail` rule, which stops further validation for a field as soon as one rule fails.
+
+```php
+$validationRules = [
+    'email' => ['bail', 'required', 'email'],
+];
+
+$dataToValidate = [
+    'email' => '',
+];
+
+$result = Validator::make($validationRules, $dataToValidate);
+
+if ($result->isFailed()) {
+    echo "Validation failed";
+} else {
+    echo "Validation successful!";
+}
+
+$dataToValidate['email'] = 'invalid-email';
+$result = Validator::make($validationRules, $dataToValidate);
+
+if ($result->isFailed()) {
+    echo "Validation failed";
+} else {
+    echo "Validation successful!";
+}
+```
+
+---
 [^ Back to top](#table-of-contents)
 
 [<< Back to Readme](../Readme.md)

--- a/src/Contracts/CustomRule.php
+++ b/src/Contracts/CustomRule.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Azolee\Validator\Contracts;
+
+interface CustomRule
+{
+    /**
+     * Validate the given value.
+     *
+     * @param mixed $value The value to validate.
+     * @param string $key The key of the field being validated.
+     * @param mixed $dataToValidate The entire data set being validated.
+     * @return bool True if validation passes, false otherwise.
+     */
+    public function validate(mixed $value, string $key, mixed $dataToValidate): bool;
+
+    /**
+     * Get the error message for the rule.
+     *
+     * @return string The error message.
+     */
+    public function message(): string;
+}

--- a/src/ValidationRuleEvaluator.php
+++ b/src/ValidationRuleEvaluator.php
@@ -2,6 +2,7 @@
 
 namespace Azolee\Validator;
 
+use Azolee\Validator\Contracts\CustomRule;
 use Azolee\Validator\Exceptions\InvalidValidationRule;
 use Azolee\Validator\Helpers\ArrayHelper;
 use Azolee\Validator\Helpers\ClassHelper;
@@ -10,12 +11,7 @@ use ReflectionException;
 
 class ValidationRuleEvaluator
 {
-    protected ValidationErrorManager $errorManager;
-
-    public function __construct(ValidationErrorManager $errorManager)
-    {
-        $this->errorManager = $errorManager;
-    }
+    public function __construct(protected ValidationErrorManager $errorManager) {}
 
     /**
      * @throws InvalidValidationRule
@@ -28,11 +24,31 @@ class ValidationRuleEvaluator
             $rules = (is_string($rules) && str_contains($rules, '|')) ? explode('|', $rules) : [$rules];
         }
 
+        $bail = false;
+
         foreach ($rules as $rule) {
+            if ($rule === 'bail') {
+                $bail = true;
+                continue;
+            }
+
+            if ($rule instanceof CustomRule) {
+                if (!$rule->validate($dataToValidate[$key] ?? null, $key, $dataToValidate)) {
+                    $this->errorManager->setFailed($rule::class, $key, $dataToValidate, $rule->message());
+                    if ($bail) {
+                        return null;
+                    }
+                }
+                $validated[] = $key;
+                continue;
+            }
+
             if (ClassHelper::isCallable($rule)) {
                 if ($this->applyCallableRule($rule, $key, $dataToValidate) === false) {
                     $this->errorManager->setFailed('custom_rule', $key, $dataToValidate);
-                    return null;
+                    if ($bail) {
+                        return null;
+                    }
                 }
                 $validated[] = $key;
                 continue;
@@ -40,9 +56,12 @@ class ValidationRuleEvaluator
 
             if ($this->applyRule($rule, $key, $dataToValidate) === false) {
                 $this->errorManager->setFailed($rule, $key, $dataToValidate);
-                return null;
+                if ($bail) {
+                    return null;
+                }
+            } else {
+                $validated[] = $key;
             }
-            $validated[] = $key;
         }
         return $validated;
     }

--- a/tests/Rules/BailRuleTest.php
+++ b/tests/Rules/BailRuleTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Rules;
+
+use Azolee\Validator\ValidationErrorManager;
+use Azolee\Validator\ValidationRuleEvaluator;
+use PHPUnit\Framework\TestCase;
+
+class BailRuleTest extends TestCase
+{
+    public function testBailRuleStopsFurtherValidation()
+    {
+        $dataToValidate = [
+            'email' => 'invalid-email',
+        ];
+
+        $rules = ['bail', 'email', 'min:30', 'required'];
+
+        $errorManager = new ValidationErrorManager();
+        $ruleEvaluator = new ValidationRuleEvaluator($errorManager);
+
+        $result = $ruleEvaluator->evaluate($rules, 'email', $dataToValidate);
+
+        // Assert that validation stops after the first failure
+        $this->assertNull($result);
+
+        // Assert that only the first rule failure is recorded
+        $failedRules = $errorManager->getValidationResult()->getFailedRules();
+
+        $this->assertCount(1, $failedRules);
+        $this->assertEquals('email', $failedRules[0]['rule']);
+    }
+
+    public function testBailRuleAllowsValidationWithoutFailures()
+    {
+        $dataToValidate = [
+            'email' => 'test@example.com',
+        ];
+
+        $rules = 'bail|required|email';
+
+        $errorManager = new ValidationErrorManager();
+        $ruleEvaluator = new ValidationRuleEvaluator($errorManager);
+
+        $result = $ruleEvaluator->evaluate($rules, 'email', $dataToValidate);
+
+        // Assert that validation passes
+        $this->assertNotNull($result);
+        $this->assertContains('email', $result);
+
+        // Assert that no rules failed
+        $this->assertFalse($errorManager->getValidationResult()->isFailed());
+    }
+}


### PR DESCRIPTION
This pull request introduces the `bail` validation rule to the Azolee Validator library, which stops further validation for a field as soon as one rule fails. It also includes updates to the documentation, implementation, and tests to support this new feature. Additionally, a new `CustomRule` interface has been added to standardize custom validation rules.

### New Feature: `bail` Validation Rule
* **Documentation Updates**:
  - Added a description of the `bail` rule in `docs/Rules.md`, explaining its purpose and usage.
  - Provided an example of using the `bail` rule in `docs/SimpleExamples.md`, demonstrating how it stops further validation after the first failure.

* **Implementation**:
  - Modified `src/ValidationRuleEvaluator.php` to handle the `bail` rule by introducing a flag that stops further validation upon the first failure.
  - Updated the constructor in `ValidationRuleEvaluator` to use a property promotion for cleaner code.

### Support for Custom Validation Rules
* **New Interface**:
  - Added a `CustomRule` interface in `src/Contracts/CustomRule.php` to define a standard structure for custom validation rules, including methods for validation and error messages.
  - Imported the `CustomRule` interface in `src/ValidationRuleEvaluator.php` to integrate custom rules into the evaluator.

### Tests for `bail` Rule
* **Unit Tests**:
  - Added `tests/Rules/BailRuleTest.php` to verify the behavior of the `bail` rule, ensuring it stops validation after the first failure and allows validation to proceed when there are no failures.