### PR TITLE
Add html_safe, mac_address, and domain validation rules with docs; improve null/empty handling and bail rule logic

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -188,9 +188,34 @@ This document describes the validation rules available in the `Azolee\Validator\
 - **Parameters**:
   - `value` (int): The maximum number of words allowed.
 
+### `html_safe`
+- **Description**: Validates that the string contains only safe HTML.
+- **Usage**: `html_safe` or `html_safe:a,p,br`
+- **Notes**:
+    - Disallows dangerous tags (script, iframe, object, embed, link, meta, style, form, input, button, textarea, select).
+    - Disallows event attributes (on*) and javascript: URLs.
+    - Allowed tags (default): a, b, strong, em, i, u, br, p, ul, ol, li, span.
+    - Allowed attributes: href, title, rel, target, class, id, alt.
+
+### `mac_address`
+- **Description**: Validates that the value is a valid MAC address.
+- **Usage**: `mac_address`
+- **Supported formats**:
+    - `00:1A:2B:3C:4D:5E`
+    - `00-1A-2B-3C-4D-5E`
+    - `001A.2B3C.4D5E`
+    - `001A2B3C4D5E`
+
+### `domain`
+- **Description**: Validates that the value is a valid domain name (hostname), not a URL.
+- **Usage**: `domain`
+- **Notes**:
+    - Syntax-only check using PHP’s FILTER_VALIDATE_DOMAIN with FILTER_FLAG_HOSTNAME.
+
 ### `bail`
 - **Description**: Stops further validation for a field as soon as one rule fails.
 - **Usage**: `bail`
+
 
 
 ## Callable Rules

--- a/docs/SimpleExamples.md
+++ b/docs/SimpleExamples.md
@@ -27,6 +27,9 @@
 25. [Slug](#example-slug)
 26. [IBAN](#example-iban)
 27. [Hex Color](#example-hex-color)
+28. [HTML Safe](#example-html-safe)
+29. [MAC Address](#example-mac-address)
+30. [Domain](#example-domain)
 
 
 
@@ -1088,6 +1091,85 @@ if ($result->isFailed()) {
 } else {
     echo "Validation successful!";
 }
+```
+
+### Example: `HTML Safe`
+
+The html_safe rule only allows safe HTML elements (dangerous tags, on* attributes, and javascript: are disallowed). Default allowed tags: a, b, strong, em, i, u, br, p, ul, ol, li, span. You can optionally specify your own list.
+
+```php
+<?php
+use Azolee\Validator\Validator;
+
+// HTML Safe example
+$validationRules = [
+    // allow only p, a, br tags
+    'content' => 'html_safe:p,a,br',
+];
+
+$dataToValidate = [
+    'content' => '<p>Hello <a href="https://example.com" target="_blank" rel="noopener">world</a><br></p>',
+];
+
+$result = Validator::make($validationRules, $dataToValidate);
+echo $result->isFailed() ? 'Validation failed' : 'Validation successful!';
+
+// Unsafe HTML (should fail)
+$dataToValidate['content'] = '<script>alert(1)</script><p onclick="evil()">Hi</p>';
+$result = Validator::make($validationRules, $dataToValidate);
+echo $result->isFailed() ? 'Validation failed' : 'Validation successful!';
+```
+
+### Example: `MAC Address`
+
+The mac_address rule validates the MAC address format. Supported formats: 00:1A:2B:3C:4D:5E, 00-1A-2B-3C-4D-5E, 001A.2B3C.4D5E, 001A2B3C4D5E.
+
+```php
+<?php
+use Azolee\Validator\Validator;
+
+// MAC Address example
+$validationRules = [
+    'device_mac' => 'mac_address',
+];
+
+$dataToValidate = [
+    'device_mac' => '00:1A:2B:3C:4D:5E',
+];
+
+$result = Validator::make($validationRules, $dataToValidate);
+echo $result->isFailed() ? 'Validation failed' : 'Validation successful!';
+
+// Invalid MAC (should fail)
+$dataToValidate['device_mac'] = '00:1G:2B:3C:4D:5E';
+$result = Validator::make($validationRules, $dataToValidate);
+echo $result->isFailed() ? 'Validation failed' : 'Validation successful!';
+```
+
+### Example: `Domain`
+
+The domain rule checks the syntax of a domain name (hostname) (not a full URL, and no DNS validation).
+
+```php
+<?php
+use Azolee\Validator\Validator;
+
+// Domain example
+$validationRules = [
+    'host' => 'domain',
+];
+
+$dataToValidate = [
+    'host' => 'example.com',
+];
+
+$result = Validator::make($validationRules, $dataToValidate);
+echo $result->isFailed() ? 'Validation failed' : 'Validation successful!';
+
+// Invalid: this is a URL, not a plain domain (should fail)
+$dataToValidate['host'] = 'https://example.com';
+$result = Validator::make($validationRules, $dataToValidate);
+echo $result->isFailed() ? 'Validation failed' : 'Validation successful!';
 ```
 
 ---

--- a/src/ValidationErrorBag.php
+++ b/src/ValidationErrorBag.php
@@ -51,6 +51,9 @@ class ValidationErrorBag implements ValidationErrorBagInterface
         'timezone' => 'The :attribute is not a valid timezone.',
         'min_words' => 'The :attribute must be at least :value words long.',
         'max_words' => 'The :attribute must be at most :value words long.',
+        'html_safe' => 'The :attribute contains unsafe HTML.',
+        'mac_address' => 'The :attribute must be a valid MAC address.',
+        'domain' => 'The :attribute must be a valid domain name.',
     ];
 
     /**

--- a/src/ValidationRuleEvaluator.php
+++ b/src/ValidationRuleEvaluator.php
@@ -35,7 +35,6 @@ class ValidationRuleEvaluator
         }
         $rules = $filteredRules;
 
-
         foreach ($rules as $rule) {
 
             if ($rule instanceof CustomRule) {

--- a/src/ValidationRuleEvaluator.php
+++ b/src/ValidationRuleEvaluator.php
@@ -25,12 +25,18 @@ class ValidationRuleEvaluator
         }
 
         $bail = false;
-
+        $filteredRules = [];
         foreach ($rules as $rule) {
-            if ($rule === 'bail') {
+            if (is_string($rule) && $rule === ValidationRules::BAIL_RULE) {
                 $bail = true;
                 continue;
             }
+            $filteredRules[] = $rule;
+        }
+        $rules = $filteredRules;
+
+
+        foreach ($rules as $rule) {
 
             if ($rule instanceof CustomRule) {
                 if (!$rule->validate($dataToValidate[$key] ?? null, $key, $dataToValidate)) {

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -252,12 +252,13 @@ class ValidationRules
      */
     public static function same(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
-        if (empty($data)) {
+        if (is_null($data)) {
             return true;
         }
         $fieldToCompare = ArrayHelper::parseNestedData($dataToValidate, $value)[0] ?? ['value' => null];
         return $data === $fieldToCompare['value'];
     }
+
 
     /**
      * @param mixed $data

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -8,6 +8,7 @@ use Azolee\Validator\Validators\Base64Validator;
 class ValidationRules
 {
     public const CUSTOM_RULE = 'custom_rule';
+    public const BAIL_RULE = 'bail';
 
     /**
      * @param mixed $data
@@ -18,7 +19,7 @@ class ValidationRules
      */
     public static function array(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
-        return is_array($data);
+        return is_null($data) || is_array($data);
     }
 
     /**
@@ -81,7 +82,7 @@ class ValidationRules
      */
     public static function email(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
-        return filter_var($data, FILTER_VALIDATE_EMAIL) !== false;
+        return is_null($data) || filter_var($data, FILTER_VALIDATE_EMAIL) !== false;
     }
 
     /**
@@ -93,7 +94,7 @@ class ValidationRules
      */
     public static function url(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
-        return filter_var($data, FILTER_VALIDATE_URL) !== false;
+        return is_null($data) || filter_var($data, FILTER_VALIDATE_URL) !== false;
     }
 
     /**
@@ -105,6 +106,9 @@ class ValidationRules
      */
     public static function min(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
+        if (is_null($data)) {
+            return true;
+        }
         if (is_numeric($data)) {
             return $data >= $value;
         }
@@ -126,6 +130,9 @@ class ValidationRules
      */
     public static function max(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
+        if (is_null($data)) {
+            return true;
+        }
         if (is_numeric($data)) {
             return $data <= $value;
         }
@@ -147,6 +154,9 @@ class ValidationRules
      */
     public static function in(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
+        if (is_null($data)) {
+            return true;
+        }
         return in_array($data, explode(',', $value));
     }
 
@@ -159,7 +169,7 @@ class ValidationRules
      */
     public static function date(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
-        return strtotime($data) !== false;
+        return is_null($data) || strtotime($data) !== false;
     }
 
     /**
@@ -171,6 +181,9 @@ class ValidationRules
      */
     public static function alpha(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
+        if (empty($data)) {
+            return true;
+        }
         return extension_loaded('ctype') ? ctype_alpha($data) : (preg_match('/^[a-zA-Z]+$/', $data) === 1);
     }
 
@@ -183,6 +196,9 @@ class ValidationRules
      */
     public static function alpha_num(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
+        if (empty($data)) {
+            return true;
+        }
         return extension_loaded('ctype') ? ctype_alnum($data) : (preg_match('/^[a-zA-Z0-9]+$/', $data) === 1);
     }
 
@@ -195,7 +211,7 @@ class ValidationRules
      */
     public static function digits(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
-        return is_numeric($data) && strlen((string)$data) == $value;
+        return is_null($data) || (is_numeric($data) && strlen((string)$data) == $value);
     }
 
     /**
@@ -207,6 +223,9 @@ class ValidationRules
      */
     public static function digits_between(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
+        if (empty($data)) {
+            return true;
+        }
         [$min, $max] = explode(',', $value);
         $length = strlen((string)$data);
         return is_numeric($data) && $length >= $min && $length <= $max;
@@ -221,7 +240,7 @@ class ValidationRules
      */
     public static function different(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
-        return !static::same($data, $key, $value, $dataToValidate);
+        return is_null($data) || !static::same($data, $key, $value, $dataToValidate);
     }
 
     /**
@@ -233,6 +252,9 @@ class ValidationRules
      */
     public static function same(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
+        if (empty($data)) {
+            return true;
+        }
         $fieldToCompare = ArrayHelper::parseNestedData($dataToValidate, $value)[0] ?? ['value' => null];
         return $data === $fieldToCompare['value'];
     }
@@ -246,7 +268,7 @@ class ValidationRules
      */
     public static function ip(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
-        return filter_var($data, FILTER_VALIDATE_IP) !== false;
+        return is_null($data) || filter_var($data, FILTER_VALIDATE_IP) !== false;
     }
 
     /**
@@ -258,6 +280,9 @@ class ValidationRules
      */
     public static function json(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
     {
+        if (empty($data)) {
+            return true;
+        }
         json_decode($data);
         return json_last_error() === JSON_ERROR_NONE;
     }
@@ -636,5 +661,151 @@ class ValidationRules
     {
         $wordCount = str_word_count($data);
         return $wordCount <= $value;
+    }
+
+    /**
+     * Validates that the given string is safe HTML.
+     * - Disallows dangerous tags like: script, iframe, object, embed, link, meta, style, form, input, button, textarea, select
+     * - Disallows event handler attributes (on*)
+     * - Disallows javascript: URLs
+     * - Limits tags to an allowed list (default: a,b,strong,em,i,u,br,p,ul,ol,li,span). You can override via comma-separated list in $value.
+     * - Limits attributes to a safe set: href,title,rel,target,class,id,alt
+     *
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value Comma-separated allowed tags (e.g. "a,p,br")
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function html_safe(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        if ($data === null || $data === '') {
+            return true;
+        }
+        if (!is_string($data)) {
+            return false;
+        }
+
+        $allowedTags = $value
+            ? array_values(array_filter(array_map(static fn($t) => strtolower(trim($t)), explode(',', (string)$value))))
+            : ['a', 'b', 'strong', 'em', 'i', 'u', 'br', 'p', 'ul', 'ol', 'li', 'span'];
+
+        $disallowedTags = ['script', 'iframe', 'object', 'embed', 'link', 'meta', 'style', 'form', 'input', 'button', 'textarea', 'select'];
+        $safeAttributes = ['href', 'title', 'rel', 'target', 'class', 'id', 'alt'];
+
+        $lower = strtolower($data);
+
+        foreach ($disallowedTags as $tag) {
+            if (strpos($lower, "<{$tag}") !== false || strpos($lower, "</{$tag}") !== false) {
+                return false;
+            }
+        }
+        if (stripos($lower, 'javascript:') !== false) {
+            return false;
+        }
+        if (preg_match('/\son[a-z0-9_-]+\s*=/i', $lower) === 1) {
+            return false;
+        }
+
+        if (preg_match_all('/<\s*\/?\s*([a-z0-9]+)([^>]*)>/i', $data, $matches)) {
+            $tags = $matches[1];
+            $attrs = $matches[2];
+
+            foreach ($tags as $tag) {
+                $t = strtolower($tag);
+                if (!in_array($t, $allowedTags, true)) {
+                    return false;
+                }
+            }
+
+            foreach ($attrs as $attrChunk) {
+                if (trim($attrChunk) === '') {
+                    continue;
+                }
+
+                if (preg_match('/\bon[a-z0-9_-]+\b/i', $attrChunk) === 1) {
+                    return false;
+                }
+
+                if (preg_match_all('/([a-z0-9:-]+)\s*=\s*("[^"]*"|\'[^\']*\'|[^"\'>\s]+)/i', $attrChunk, $attrMatches)) {
+                    $names = $attrMatches[1];
+                    $values = $attrMatches[2];
+                    foreach ($names as $idx => $name) {
+                        $an = strtolower($name);
+                        if (!in_array($an, $safeAttributes, true)) {
+                            return false;
+                        }
+                        if (in_array($an, ['href', 'src'], true)) {
+                            $val = strtolower(trim($values[$idx], " \t\n\r\0\x0B\"'"));
+                            if (str_starts_with($val, 'javascript:')) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates that the given value is a MAC address.
+     * Supported formats:
+     * - 00:1A:2B:3C:4D:5E
+     * - 00-1A-2B-3C-4D-5E
+     * - 001A.2B3C.4D5E
+     * - 001A2B3C4D5E
+     *
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function mac_address(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        if ($data === null || $data === '') {
+            return true;
+        }
+        if (!is_string($data)) {
+            return false;
+        }
+
+        $patterns = [
+            '/^([0-9A-Fa-f]{2}[:\-]){5}[0-9A-Fa-f]{2}$/',
+            '/^([0-9A-Fa-f]{4}\.){2}[0-9A-Fa-f]{4}$/',
+            '/^[0-9A-Fa-f]{12}$/',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $data) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Validates that the given value is a valid domain name (hostname).
+     * Note: This validates the syntax of a domain (not a URL and not DNS existence).
+     *
+     * @param mixed $data
+     * @param string|null $key
+     * @param mixed|null $value
+     * @param array $dataToValidate
+     * @return bool
+     */
+    public static function domain(mixed $data, ?string $key = null, mixed $value = null, array $dataToValidate = []): bool
+    {
+        if ($data === null || $data === '') {
+            return true;
+        }
+        if (!is_string($data)) {
+            return false;
+        }
+
+        return filter_var($data, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false;
     }
 }


### PR DESCRIPTION
This pull request adds three new validation rules (`html_safe`, `mac_address`, and `domain`) to the Validator library, improves documentation with usage examples, and makes several rules more permissive by treating null or empty values as valid in most cases. It also introduces a constant for the bail rule and refines how rules are processed internally.

### New validation rules and documentation

* Added `html_safe`, `mac_address`, and `domain` validation rules to `ValidationRules`, including detailed documentation and usage examples in `docs/Rules.md` and `docs/SimpleExamples.md`.
* Added corresponding error messages for the new rules in `ValidationErrorBag.php`.

### Rule processing improvements

* Introduced the `BAIL_RULE` constant in `ValidationRules.php` and updated `ValidationRuleEvaluator.php` to use it for improved bail rule handling. 

### Permissiveness for null/empty values

* Updated many validation rules (e.g., `array`, `email`, `url`, `min`, `max`, `in`, `date`, `alpha`, `alpha_num`, `digits`, `digits_between`, `different`, `same`, `ip`, `json`) to treat null or empty values as valid, making validations more permissive and preventing unnecessary failures for missing data. 

These changes collectively expand the validator's capabilities, improve its usability, and make it more robust for real-world data scenarios.